### PR TITLE
Remove PPI fields on export

### DIFF
--- a/src/Serverfireteam/Panel/stubs/model-referrals.stub
+++ b/src/Serverfireteam/Panel/stubs/model-referrals.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyClass extends Model {
+
+    protected $table = 'DummyClass';
+
+
+
+	public static function panelExport() {
+
+		return self::all()->filter(function($item) {
+			$item->setHidden([
+				'ip_address',
+				'phone',
+				'first_name',
+				'middle_initial',
+				'last_name',
+				'email',
+				'address1',
+				'address2',
+				'city',
+				'state',
+				'zip',
+				'country',
+			]);
+			return $item;
+		});
+	}
+
+}

--- a/src/Serverfireteam/Panel/stubs/model-responses.stub
+++ b/src/Serverfireteam/Panel/stubs/model-responses.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyClass extends Model {
+
+    protected $table = 'DummyClass';
+
+
+
+	public static function panelExport() {
+
+		return self::all()->filter(function($item) {
+			$item->setHidden([
+				'ip_address',
+				'phone',
+				'first_name',
+				'middle_initial',
+				'last_name',
+				'email',
+				'address1',
+				'address2',
+				'city',
+				'state',
+				'zip',
+				'country',
+			]);
+			return $item;
+		});
+	}
+
+}

--- a/src/Serverfireteam/Panel/stubs/model.stub
+++ b/src/Serverfireteam/Panel/stubs/model.stub
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace DummyNamespace;
 
@@ -7,5 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 class DummyClass extends Model {
 
     protected $table = 'DummyClass';
+
+
+	public static function panelExport() {
+		return self::all();
+	}
 
 }

--- a/src/controllers/ExportImportController.php
+++ b/src/controllers/ExportImportController.php
@@ -13,7 +13,7 @@ class ExportImportController extends Controller {
 
         $className = $appHelper->getNameSpace() . $entity;
 
-        $modelData = $className::all();
+        $modelData = $className::panelExport();
 
         ini_set('max_execution_time', 300);
         ini_set('memory_limit', '1024M');


### PR DESCRIPTION
A little messy putting this into panel, but I didn't see a cleaner way that didn't involve the developer manually doing something like this after running `blueprint:install`. In this, export uses a new model method called panelExport() instead of all(), and the stub files used to generate these fake classes for the panel to allow overrides on a per-model basis, so there's a model-referrals.stub, model-responses.stub, and sites will use the model.stub file which also has the new panelExport() method which just calls all() since we don't need to modify it.